### PR TITLE
Add use strict for Node < v6.x users

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 // Copyright 2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE
+"use strict";
 
 const lighthouse = require('lighthouse');
 const Chart = require('cli-chart');

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
   "bugs": {
     "url": "https://github.com/paulirish/pwmetrics/issues"
   },
-  "homepage": "https://github.com/paulirish/pwmetrics#readme"
+  "homepage": "https://github.com/paulirish/pwmetrics#readme",
+  "engines" : {
+    "node" : ">= 4.4.6"
+  }
 }


### PR DESCRIPTION
Block-scoped declarations (let, const, function, class) not yet supported outside strict mode for Node < v6.x.