### PR TITLE
Add missed barLabel

### DIFF
--- a/lib/chart/bar.js
+++ b/lib/chart/bar.js
@@ -7,6 +7,7 @@ var Bar = module.exports = function(chart, opts) {
   this.size = opts.size;
   this.color = opts.color || defaults.color;
   this.label = opts.label;
+  this.barLabel = opts.barLabel;
 };
 
 Bar.prototype.draw = function(scale) {
@@ -29,4 +30,8 @@ Bar.prototype.draw = function(scale) {
     }
   }
   charm.display('reset');
+
+  if (this.barLabel) {
+    charm.write(' ' + this.barLabel);
+  }
 };


### PR DESCRIPTION
`barLabel` was missed during chart moving in repo. I added changes due to https://github.com/samccone/cli-chart/pull/2/files

This should fix #22 
![barlabel](https://cloud.githubusercontent.com/assets/6231516/21805497/25a21af8-d73d-11e6-84ae-8e63c4da48c6.png)
