### PR TITLE
Add default display of chart alongside expectations

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -86,10 +86,11 @@ class PWMetrics {
   displayOutput(data) {
     if (this.flags.json) {
       return data;
-    } else if (this.flags.expectations) {
-      expectations.checkExpectations(data.timings, this.expectations.metrics)
     } else {
       this.showChart(data);
+      if (this.flags.expectations) {
+        expectations.checkExpectations(data.timings, this.expectations.metrics);
+      }
     }
     return data;
   }


### PR DESCRIPTION
Addresses https://github.com/paulirish/pwmetrics/issues/32

This PR enables default display of the chart when `expectations` are present, and adds a new `disableChart` option that can be used to output expectation errors and warnings alone.