### PR TITLE
Add missing metrics validation and normalization to PWMetrics constructor

### DIFF
--- a/lib/expectations.js
+++ b/lib/expectations.js
@@ -53,7 +53,8 @@ function checkExpectations(metricsData, expectationMetrics) {
   });
 }
 
-
 module.exports = {
-  checkExpectations
+  checkExpectations,
+  validateMetrics,
+  normalizeMetrics
 };

--- a/lib/expectations.js
+++ b/lib/expectations.js
@@ -31,9 +31,6 @@ function normalizeMetrics(metrics) {
 }
 
 function checkExpectations(metricsData, expectationMetrics) {
-  validateMetrics(expectationMetrics);
-  expectationMetrics = normalizeMetrics(expectationMetrics);
-
   metricsData.forEach(metric => {
     const metricName = metric.name;
     const expectationValue = expectationMetrics[metricName];

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,10 +91,11 @@ class PWMetrics {
   displayOutput(data) {
     if (this.flags.json) {
       return data;
-    } else if (this.flags.expectations) {
-      expectations.checkExpectations(data.timings, this.expectations.metrics)
     } else {
       this.showChart(data);
+      if (this.flags.expectations) {
+        expectations.checkExpectations(data.timings, this.expectations.metrics);
+      }
     }
     return data;
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,8 +28,8 @@ class PWMetrics {
     this.sheets = opts.sheets;
     this.expectations = opts.expectations;
 
-    expectations.validateMetrics(this.metrics);
-    expectations.normalizeMetrics(this.metrics);
+    expectations.validateMetrics(this.expectations.metrics);
+    expectations.normalizeMetrics(this.expectations.metrics);
   }
 
   start() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,8 +28,10 @@ class PWMetrics {
     this.sheets = opts.sheets;
     this.expectations = opts.expectations;
 
-    expectations.validateMetrics(this.expectations.metrics);
-    expectations.normalizeMetrics(this.expectations.metrics);
+    if (this.expectations && this.expectations.metrics) {
+      expectations.validateMetrics(this.expectations.metrics);
+      expectations.normalizeMetrics(this.expectations.metrics);
+    }
   }
 
   start() {
@@ -89,11 +91,10 @@ class PWMetrics {
   displayOutput(data) {
     if (this.flags.json) {
       return data;
+    } else if (this.flags.expectations) {
+      expectations.checkExpectations(data.timings, this.expectations.metrics)
     } else {
       this.showChart(data);
-      if (this.flags.expectations) {
-        expectations.checkExpectations(data.timings, this.expectations.metrics);
-      }
     }
     return data;
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,9 @@ class PWMetrics {
     this.runs = this.flags.runs || 1;
     this.sheets = opts.sheets;
     this.expectations = opts.expectations;
+
+    expectations.validateMetrics(this.metrics);
+    expectations.normalizeMetrics(this.metrics);
   }
 
   start() {


### PR DESCRIPTION
Addresses https://github.com/paulirish/pwmetrics/issues/36

Also might be worth updating the readme demo configs to simply omit the `>=`. Is there a reason why those are included if they're just later stripped?