### PR TITLE
WIP: Added no url error and —help message if cli tool misused.

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,6 +10,7 @@ const yargs = require('yargs');
 const PWMetrics = require('../lib/index');
 const { getConfigFromFile } = require('../lib/utils/fs');
 const { getMessageWithPrefix, getMessage } = require('../lib/utils/messages');
+let config;
 
 const cliFlags = yargs
   .help('help')
@@ -47,9 +48,7 @@ const cliFlags = yargs
   })
   .option('config', {
     'describe': 'Path to config file',
-    'type': 'string',
-    //equivalent to: cliFlags.config = getConfigFromFile(cliFlags.config);
-    'coerce': getConfigFromFile 
+    'type': 'string'    
   })
   .option('disable-cpu-throttling', {
     'describe': 'Disable CPU throttling',
@@ -58,7 +57,9 @@ const cliFlags = yargs
   })
   .check((argv) => {
     // Make sure pwmetrics has been passed a url, either from cli or config file
-    if (argv._.length === 0 && (argv.config === undefined || !argv.config.url))
+    if(argv.config) config = getConfigFromFile(argv.config);
+
+    if (argv._.length === 0 && (config === undefined || !config.url))
         throw new Error(getMessageWithPrefix('ERROR', 'NO_URL'));
 
     return true;
@@ -67,7 +68,7 @@ const cliFlags = yargs
   .argv;
 
 //Merge options from all sources. Order indicates precedence (last one wins)
-let options = Object.assign({}, { flags: cliFlags }, cliFlags.config);
+let options = Object.assign({}, { flags: cliFlags }, config);
 
 //Get url first from cmd line then from config file.
 options.url = cliFlags._[0] || options.url;

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -48,14 +48,14 @@ const cliFlags = yargs
   })
   .option('config', {
     'describe': 'Path to config file',
-    'type': 'string'    
+    'type': 'string'
   })
   .option('disable-cpu-throttling', {
     'describe': 'Disable CPU throttling',
     'type': 'boolean',
     'default': false
   })
-  .check((argv) => {
+  .check( (argv) => {
     // Make sure pwmetrics has been passed a url, either from cli or config file
     if(argv.config) config = getConfigFromFile(argv.config);
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -5,16 +5,24 @@
 const childProcess = require('child_process');
 const expect = require('chai').expect;
 
-describe('CLI', function() {
+describe('CLI', function () {
 
-  describe('url', () => {
+  describe('url', () => { 
+
     it('should throw error if a url is not provided by cli', () => {
-      expect(() => childProcess.execSync('node bin/cli.js')).to.throw(Error, 'Error: No url entered.');
+      try {
+        childProcess.execSync('node bin/cli.js');
+      } catch (e) {
+        expect(e.message).to.contain("No url entered..");
+      }
     });
 
     it('should throw error if a url is not provided either by config or by cli', () => {
-      expect(() => childProcess.execSync('node bin/cli.js --config=./test/fixtures/empty-config.js'))
-        .to.throw(Error, 'Error: No url entered.');
+      try {
+        childProcess.execSync('node bin/cli.js --config=./test/fixtures/empty-config.js');
+      } catch (e) {
+        expect(e.message).to.contain("No url entered..");
+      }
     });
   });
 });


### PR DESCRIPTION
This is a __work in progress__, some code cleanup currently on cli.
Its very similar to the Yargs V2 merge request but for project-consistency offers functionality akin to lighthouse at the cli-level. 

__Edit__: The tests fail because of https://github.com/paulirish/pwmetrics/blob/master/test/cli.js. Does it make sense for a cli tool to throw an Error that the OS/terminal process will catch?

__Edit 2__: Addresses https://github.com/paulirish/pwmetrics/issues/65 :

![screen shot 2017-03-07 at 09 17 08](https://cloud.githubusercontent.com/assets/3718654/23649600/e9ca470c-0316-11e7-8d72-b318426f549c.png)
