### PR TITLE
Fix hanging process after chart draw

### DIFF
--- a/lib/chart/chart.js
+++ b/lib/chart/chart.js
@@ -168,4 +168,5 @@ Chart.prototype.draw = function() {
   this.labelAxes();
   this.drawBars();
   this.charm.write('\n\n');
+  this.charm.destroy();
 };

--- a/recipes/gulp/gulpfile.js
+++ b/recipes/gulp/gulpfile.js
@@ -22,7 +22,7 @@ function handleError() {
 gulp.task('pwmetrics', function() {
   connectServer();
 
-  const url = `https://airhorner.com`;
+  const url = `http://localhost:${port}/index.html`;
   const pwMetrics = new PWMetrics(url, {
     flags: {
       expectations: true

--- a/recipes/gulp/gulpfile.js
+++ b/recipes/gulp/gulpfile.js
@@ -22,7 +22,7 @@ function handleError() {
 gulp.task('pwmetrics', function() {
   connectServer();
 
-  const url = `http://localhost:${port}/index.html`;
+  const url = `https://airhorner.com`;
   const pwMetrics = new PWMetrics(url, {
     flags: {
       expectations: true
@@ -45,7 +45,6 @@ gulp.task('pwmetrics', function() {
   return pwMetrics.start()
     .then(_ => {
       connect.serverClose();
-      process.exit(0);
     })
     .catch(_ => handleError);
 });


### PR DESCRIPTION
Linked to https://github.com/paulirish/pwmetrics/issues/88

By destroying the chart after the draw the process closes and process.exit() is no longer needed