### PR TITLE
Use push(true) and pop(true) everywhere to fix Mac Terminal positioning

### DIFF
--- a/lib/chart/bar.js
+++ b/lib/chart/bar.js
@@ -16,10 +16,10 @@ Bar.prototype.draw = function(scale) {
   const charm = this.chart.charm;
   const dir = this.chart.direction;
   if (dir === 'x' && this.label) {
-    charm.push();
+    charm.push(true);
     charm.left(this.label.length+2);
     charm.write(this.label);
-    charm.pop();
+    charm.pop(true);
   }
   charm.background(this.color);
   for (let i = 0; i < Math.round(this.size*scale); i++) {

--- a/lib/chart/chart.js
+++ b/lib/chart/chart.js
@@ -93,21 +93,21 @@ Chart.prototype.drawAxes = function() {
         // The cursor is now at the origin of the graph
 
     // draw x axis
-  charm.push();
+  charm.push(true);
 
   charm.write('\n');
   charm.right(this.lmargin);
   for (i = this.lmargin-1; i < this.width+this.lmargin-1; i++) {
     charm.write('-');
   }
-  charm.pop();
+  charm.pop(true);
 };
 
 Chart.prototype.labelAxes = function() {
   const charm = this.charm;
     // label y axis
   if (this.ylabel) {
-    charm.push();
+    charm.push(true);
     const yminstr = String(this.ymin);
     charm.left(yminstr.length+2);
     charm.write(yminstr);
@@ -123,12 +123,12 @@ Chart.prototype.labelAxes = function() {
     const ymaxstr = this.direction === 'y' ? String(this.max_size) : String(this.ymax);
     charm.left(ymaxstr.length);
     charm.write(ymaxstr);
-    charm.pop();
+    charm.pop(true);
   }
 
     // label x axis
   if (this.xlabel) {
-    charm.push();
+    charm.push(true);
     charm.write('\n\n');
     charm.right(this.lmargin+1);
     charm.write(String(this.xmin));
@@ -137,7 +137,7 @@ Chart.prototype.labelAxes = function() {
     charm.right(this.width/2 - this.xlabel.length/2);
     const xmaxstr = this.direction === 'x' ? String(this.max_bound || this.max_size) : String(this.xmax);
     charm.write(xmaxstr);
-    charm.pop();
+    charm.pop(true);
   }
 };
 
@@ -154,9 +154,9 @@ Chart.prototype.drawBars = function() {
     if (this.direction === 'x') {
       if (i !== 0) charm.up(this.step);
     } else if (i !== 0) charm.right(this.step);
-    charm.push();
+    charm.push(true);
     this.bars[i].draw(this.scale);
-    charm.pop();
+    charm.pop(true);
   }
   if (this.direction === 'x') charm.down(this.step*this.bars.length+1);
   charm.write('\n\n\n');


### PR DESCRIPTION
This includes the flag to enable `withAttributes` on all `push()` and `pop()` calls to `charm`. For whatever reason, this fixes alignment in macOS Terminal.

![screen shot 2017-04-19 at 1 30 06 pm](https://cloud.githubusercontent.com/assets/53522/25200804/7ab0cdc2-2504-11e7-9357-4affb1bb761d.png)

(This would be possible to install/test directly from this branch if [postinstall-build](https://github.com/exogen/postinstall-build) were used 😉)