### PR TITLE
bump lighthouse to d73d3a7d6

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "charm": "^1.0.2",
     "google-auth-library": "^0.10.0",
     "googleapis": "^16.0.0",
-    "lighthouse": "paulirish/lighthouse#b7756033",
+    "lighthouse": "paulirish/lighthouse#c74ea959",
     "micro-promisify": "^0.1.1",
     "readline-sync": "^1.4.6",
     "yargs": "^6.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1885,9 +1885,9 @@ liftoff@^2.1.0:
     rechoir "^0.6.2"
     resolve "^1.1.7"
 
-lighthouse@paulirish/lighthouse#b7756033:
+lighthouse@paulirish/lighthouse#c74ea959:
   version "1.6.0"
-  resolved "https://codeload.github.com/paulirish/lighthouse/tar.gz/b7756033"
+  resolved "https://codeload.github.com/paulirish/lighthouse/tar.gz/c74ea959"
   dependencies:
     axe-core "2.1.7"
     chrome-devtools-frontend "1.0.422034"


### PR DESCRIPTION
https://github.com/GoogleChrome/lighthouse/commit/d73d3a7d6b20c04d2142b329ed0c93a0415f121e fixes our #39 issue (InvalidProtoExpectation)

again i'm using a little fork where i committed the JS files built from TS. 
commit: https://github.com/paulirish/lighthouse/commit/c74ea959dd7f7c4f5ab2dfe5644dc24ed8cd6e6c

fixes #39 