### PR TITLE
Shouldn't call parseChromeFlags two times

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -48,6 +48,7 @@ class PWMetrics {
   clientSecret: AuthorizeCredentials;
   tryLighthouseCounter: number;
   launcher: LaunchedChrome;
+  parsedChromeFlags: Array<string>;
 
   constructor(public url: string, opts: MainOptions) {
     this.flags = Object.assign({}, this.flags, opts.flags);
@@ -69,7 +70,7 @@ class PWMetrics {
       } else throw new Error(messages.getMessageWithPrefix('ERROR', 'NO_EXPECTATIONS_FOUND'));
     }
 
-    this.flags.chromeFlags = parseChromeFlags(this.flags.chromeFlags);
+    this.parsedChromeFlags = parseChromeFlags(this.flags.chromeFlags);
   }
 
   async start() {
@@ -191,7 +192,7 @@ class PWMetrics {
       console.log(messages.getMessage('LAUNCHING_CHROME'));
       this.launcher = await launch({
         port: this.flags.port,
-        chromeFlags: parseChromeFlags(this.flags.chromeFlags),
+        chromeFlags: this.parsedChromeFlags,
         chromePath: this.flags.chromePath
       });
       this.flags.port = this.launcher.port;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -197,6 +197,7 @@ class PWMetrics {
       this.flags.port = this.launcher.port;
       return this.launcher;
     } catch(error) {
+      console.error(error);
       await this.killLauncher();
       return error;
     }

--- a/test/index.js
+++ b/test/index.js
@@ -27,7 +27,7 @@ describe('PWMetrics', () => {
     it('should parse chromeFlags', () => {
       const opts = Object.assign({}, runOptions.startWithChromeFlags.opts);
       const pwMetrics = new PWMetrics(runOptions.startWithChromeFlags.url, opts);
-      expect(pwMetrics.flags.chromeFlags).to.be.deep.equal(['--no-sandbox', '--disable-setuid-sandbox']);
+      expect(pwMetrics.parsedChromeFlags).to.be.deep.equal(['--no-sandbox', '--disable-setuid-sandbox']);
     });
 
     describe('expectations', () => {


### PR DESCRIPTION
## Motivation
Currently, I have this error
```
❯❯❯ pwmetrics https://airhorner.com/                                            
Launching Chrome
events.js:183
      throw er; // Unhandled 'error' event
      ^

Error: connect ECONNREFUSED 127.0.0.1:9222
    at Object._errnoException (util.js:1022:11)
    at _exceptionWithHostPort (util.js:1044:20)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1182:14)
```
Environment detail:
- MacOS
- Node v8.9.4
- pwmetrics v3.1.5

Looks like it relates to https://github.com/paulirish/pwmetrics/pull/147

cc @denar90 @paulirish @pedro93 

