### PR TITLE
fix: Missing messages for ttfi and ttci

### DIFF
--- a/lib/utils/messages.ts
+++ b/lib/utils/messages.ts
@@ -56,6 +56,10 @@ const getMessage = function (messageType: string, ...args: any[]) {
       return 'Visually Complete 100%';
     case 'tti':
       return 'Time to Interactive';
+    case 'ttfi':
+      return 'First Interactive (vBeta)';
+    case 'ttci':
+      return 'Time to Consistently Interactive (vBeta)';
     case 'vc85':
       return 'Visually Complete 85%';
     case 'SUCCESS_RUN':


### PR DESCRIPTION
It fixes a part of the #148 issue. No more errors about missing messages for `ttfi` and `ttci`.