### PR TITLE
Improve docs on JSON output

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,6 +115,8 @@ module.exports = {
     upload: true, // turn on uploading to Google Drive
     view: true, // open uploaded traces to Google Drive in DevTools
     expectations: true, // turn on assertation metrics results against provides values
+    json: true, // not required, set to true if you want json output
+    outputPath: 'stdout', // not required, only needed if you have specified json output, can be "stdout" or a path
     chromePath: '/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary', //optional path to specific Chrome location
     chromeFlags: '' // custom flags to pass to Chrome. For a full list of flags, see http://peter.sh/experiments/chromium-command-line-switches/.
     // Note: pwmetrics supports all flags from Lighthouse


### PR DESCRIPTION
I had to check source code to figure out how to bipass the charting - Just wanted JSON output.

Seemed `--json` isnt enough, you need to specify `outputPath: 'stdout'` too.