### PR TITLE
Ignore unrecorded timings when printing charts

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -240,8 +240,10 @@ class PWMetrics {
     let timings = data.timings;
 
     timings = timings.filter(r => {
-      if (r.timing === undefined) {
+      // filter out metrics that failed to record
+      if (r.timing === undefined || isNaN(r.timing)) {
         console.error(messages.getMessageWithPrefix('ERROR', 'METRIC_IS_UNAVAILABLE', r.title));
+        return false;
       }
       // don't chart hidden metrics, but include in json
       return !metrics.hiddenMetrics.includes(r.id);


### PR DESCRIPTION
This PR changes how the `showChart` method handles unrecorded metrics.

As far as I understand there is no way that metric that failed to record could be `undefined` due to this line of code:

https://github.com/paulirish/pwmetrics/blob/de89ad03de49ce7e9979ce791dd46fee414eb6ac/lib/metrics.ts#L73

Even if one of the metrics is `undefined`, these math operations will make it `NaN`. So the check that is at the moment in the `showChart` method doesn't seem to work for some time already 😅 

Another change in this PR filters out timings that weren't recorded when the chart is printed (they will still be available in the data, that is returned by the run, as with "hidden" metrics). This is due to some values that are needed for the chart not calculating correctly if they are not numbers. The previous chart, which was replaced by Wunderbar handled this by itself by ignoring all these numbers on its own but filtering them out before printing seems like a better approach to me, especially as the error is now properly printed during the run.

To test how this works, you can use https://airhorner.com/ as it seems to consistently not record FCP metric (at least for me and as metioned by some people in #175)