### PR TITLE
fix: display warnings even if no errors

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -111,7 +111,10 @@ class PWMetrics {
         return false;
       }
       const expectedErrorLimit = expectation.error;
-      return expectedErrorLimit !== undefined && timing.timing >= expectedErrorLimit;
+      const expectedWarningLimit = expectation.warn;
+      const hasErrors = expectedErrorLimit !== undefined && timing.timing >= expectedErrorLimit;
+      const hasWarnings = expectedWarningLimit !== undefined && timing.timing >= expectedWarningLimit;
+      return hasErrors || hasWarnings;
     });
   }
 


### PR DESCRIPTION
Currently no warnings are displayed until there is at least one error. That PR fixes that.