### PR TITLE
fix: exit code is 1 when expectations are not fulfilled

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,6 +6,7 @@
 /* eslint-disable no-logger */
 const sysPath = require('path');
 const fs = require('fs');
+const os = require('os');
 const yargs = require('yargs');
 
 const PWMetrics = require('../lib/index');
@@ -101,20 +102,20 @@ const writeToDisk = function(fileName, data) {
 };
 
 const pwMetrics = new PWMetrics(options.url, options);
-pwMetrics.start()
-  .then(data => {
-    if (options.flags.json) {
-      // serialize accordingly
-      data = JSON.stringify(data, null, 2) + '\n';
-      // output to file.
-      if (options.flags.outputPath != 'stdout') {
-        return writeToDisk(options.flags.outputPath, data);
-        // output to stdout
-      } else if (data) {
-        process.stdout.write(data);
-      }
+pwMetrics.start(data => {
+  if (options.flags.json) {
+    // serialize accordingly
+    const formattedData = JSON.stringify(data, null, 2) + os.EOL;
+    // output to file.
+    if (options.flags.outputPath !== 'stdout') {
+      writeToDisk(options.flags.outputPath, formattedData);
+    // output to stdout
+    } else if (formattedData) {
+      process.stdout.write(formattedData);
     }
-  }).then(() => {
+  }
+})
+  .then(() => {
     process.exit(0);
   }).catch(err => {
     logger.error(err);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -65,6 +65,11 @@ const cliFlags = yargs
     'type': 'boolean',
     'default': false
   })
+  .option('fail-on-error', {
+    'describe': 'Exit PWMetrics with an error status code after the first unfilled expectation',
+    'type': 'boolean',
+    'default': false
+  })
   .check((argv) => {
     // Make sure pwmetrics has been passed a url, either from cli or config fileg()
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -43,7 +43,8 @@ class PWMetrics {
     expectations: false,
     json: false,
     chromeFlags: '',
-    showOutput: true
+    showOutput: true,
+    failOnError: false,
   };
   runs: number;
   sheets: SheetsConfig;
@@ -111,7 +112,7 @@ class PWMetrics {
       if (hasExpectationsWarnings || hasExpectationsErrors) {
         checkExpectations(resultsToCompare, this.normalizedExpectations);
 
-        if (hasExpectationsErrors) {
+        if (hasExpectationsErrors && this.flags.failOnError) {
           throw new Error(getMessage('HAS_EXPECTATION_ERRORS'));
         }
         else {

--- a/lib/utils/logger.ts
+++ b/lib/utils/logger.ts
@@ -20,6 +20,12 @@ export class Logger {
     }
   }
 
+  warn(msg: any, ...args: any[]) {
+    if(Logger.options.showOutput){
+      console.warn(msg, ...args);
+    }
+  }
+
   error(msg: any, ...args: any[]) {
     if(Logger.options.showOutput){
       console.error(msg, ...args);

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,9 @@ pwmetrics --view
 # --expectations  Assert metrics results against provides values. See _Defining expectations_ below.
 pwmetrics --expectations
 
+# --fail-on-error  Exit PWMetrics with an error status code after the first unfilled expectation.
+pwmetrics --fail-on-error
+
 
 ```
 
@@ -123,6 +126,7 @@ module.exports = {
     chromeFlags: '', // custom flags to pass to Chrome. For a full list of flags, see http://peter.sh/experiments/chromium-command-line-switches/.
     // Note: pwmetrics supports all flags from Lighthouse
     showOutput: true // not required, set to false for pwmetrics not output any console.log messages
+    failOnError: false // not required, set to true if you want to fail the process on expectations errors
   },
   expectations: {
     // these expectations values are examples, for your cases set your own

--- a/types/types.ts
+++ b/types/types.ts
@@ -28,6 +28,7 @@ export interface FeatureFlags {
   chromePath?: string;
   port?: number;
   showOutput: Boolean;
+  failOnError: Boolean;
 }
 
 export interface MetricsResults {


### PR DESCRIPTION
Fix #193 

A bit of refact of the `start` method, in order to return 1 as the exit code when expectations have errors.
