### PR TITLE
Add option to upload median run to Google Sheets (#201 and #199?)

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -102,7 +102,14 @@ class PWMetrics {
       this.displayOutput(results.median);
     } else if (this.flags.submit) {
       const sheets = new Sheets(this.sheets, this.clientSecret);
-      await sheets.appendResults(results.runs);
+
+      if (this.sheets.options.uploadMedian) {
+        results.median = this.findMedianRun(results.runs);
+        await sheets.appendResults([results.median,]);
+      }
+      else {
+        await sheets.appendResults(results.runs);
+      }
     }
 
     await this.outputData(results);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -105,7 +105,7 @@ class PWMetrics {
 
       if (this.sheets.options.uploadMedian) {
         results.median = this.findMedianRun(results.runs);
-        await sheets.appendResults([results.median,]);
+        await sheets.appendResults([results.median]);
       }
       else {
         await sheets.appendResults(results.runs);

--- a/readme.md
+++ b/readme.md
@@ -154,7 +154,8 @@ module.exports = {
     type: 'GOOGLE_SHEETS', // sheets service type. Available types: GOOGLE_SHEETS
     options: {
       spreadsheetId: 'sheet_id',
-      tableName: 'data'
+      tableName: 'data',
+      uploadMedian: false // not required, set to true if you want to upload only the median run
     }
   },
   clientSecret: {

--- a/types/types.ts
+++ b/types/types.ts
@@ -7,6 +7,7 @@ export interface SheetsConfig {
     spreadsheetId: string;
     tableName: string;
     clientSecret: AuthorizeCredentials;
+    uploadMedian?: boolean;
   };
 }
 


### PR DESCRIPTION
This addresses #201 and I think #199 by adding a flag which allows configuration to choose only the median run for upload to sheets.

I'm having some issues building locally which seem to be related to `@types/node`, but did manage to work around those and test that this works.