### PR TITLE
Fix TypeScript for API users

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -242,4 +242,4 @@ class PWMetrics {
   }
 }
 
-module.exports = PWMetrics;
+export = PWMetrics;

--- a/types/types.ts
+++ b/types/types.ts
@@ -12,7 +12,7 @@ export interface SheetsConfig {
 }
 
 export interface MainOptions {
-  flags?: FeatureFlags;
+  flags?: Partial<FeatureFlags>;
   sheets?: SheetsConfig;
   expectations?: ExpectationMetrics;
   clientSecret?: AuthorizeCredentials;


### PR DESCRIPTION
Hi.
This PR solves 2 problems so as to utilize the API with TypeScript.

- It's needed to write `export = PWMetrics` instead of  `module.exports = PWMetrics` for TypeScript. `export = ` is converted into `module.exports = ` end it provides to TypeScript compiler the information that `PWMetrics` is exported.
- It's needed to wrap `FeatureFlags` by `Partial` in order to avoid writing all properties. As reading this library's document, it seems that we don't have to enumerate all flags.  