### PR TITLE
Add support for custom median metric and averages

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -67,6 +67,12 @@ const cliFlags = yargs
     'type': 'boolean',
     'default': false
   })
+  .option('metric', {
+    'describe': 'Metric to use to find the median run (SI, TTI, etc.), or ' +
+                '\'all\' to report all medians or \'average\' to report all averages',
+    'type': 'string',
+    'default': 'TTFCPUIDLE',
+  })
   .check((argv) => {
     // Make sure pwmetrics has been passed a url, either from cli or config fileg()
 

--- a/types/types.ts
+++ b/types/types.ts
@@ -30,6 +30,7 @@ export interface FeatureFlags {
   port?: number;
   showOutput: Boolean;
   failOnError: Boolean;
+  metric: string;
   outputPath: string;
 }
 


### PR DESCRIPTION
Included changes:
* Fixes the `@fixme` for choosing the median result by actually basing the decision off the index of the median value instead of looking up the median value
* Adds a new `metric` flag which can specify the metric to be used for the median run calculation, defaulting to `TTFCPUIDLE`
* Also adds support for two special values for the metric flag, although they may be better off broken out into separate flags?
  * `metric=all` will report the medians for all metrics independently instead of the single run for the median of a single metric
  * `metric=average` will report the average for all metrics independently instead of the single run for the median of a single metric

Implements #218 
