### PR TITLE
Update Lighthouse to version 6

### DIFF
--- a/lib/expectations.ts
+++ b/lib/expectations.ts
@@ -1,6 +1,7 @@
 // Copyright 2016 Google Inc. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE
 
+import {DEPRECATED_METRICS} from './metrics/metrics';
 import {Logger} from './utils/logger';
 import {getAssertionMessage, getMessageWithPrefix} from './utils/messages';
 import {Timing, ExpectationMetrics, NormalizedExpectationMetrics} from '../types/types';
@@ -22,6 +23,18 @@ export const validateMetrics = (metrics: ExpectationMetrics) => {
     }
   });
 };
+
+export const clarifyMetrics = (metrics: ExpectationMetrics): ExpectationMetrics => {
+  const result: ExpectationMetrics = {};
+  Object.keys(metrics).forEach(key => {
+    if (DEPRECATED_METRICS.includes(key)) {
+      logger.warn(getMessageWithPrefix('WARNING', 'METRIC_IS_DEPRECATED', key));
+    } else {
+      result[key] = metrics[key];
+    }
+  });
+  return result;
+}
 
 export const normalizeExpectationMetrics = (metrics: ExpectationMetrics): NormalizedExpectationMetrics => {
   let normalizedMetrics: NormalizedExpectationMetrics = {};

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -204,13 +204,14 @@ class PWMetrics {
     return data;
   }
 
+  /** Median run selected by run with the median TTI. */
   findMedianRun(results: MetricsResults[]): MetricsResults {
-    const TTFCPUIDLEValues = results.map(r => r.timings.find(timing => timing.id === METRICS.TTFCPUIDLE).timing);
-    const medianTTFCPUIDLE = this.median(TTFCPUIDLEValues);
+    const TTIValues = results.map(r => r.timings.find(timing => timing.id === METRICS.TTI).timing);
+    const medianTTI = this.median(TTIValues);
     // in the case of duplicate runs having the exact same TTFI, we naively pick the first
     // @fixme, but any for now...
     return results.find((result: any) => result.timings.find((timing: any) =>
-      timing.id === METRICS.TTFCPUIDLE && timing.timing === medianTTFCPUIDLE
+      timing.id === METRICS.TTI && timing.timing === medianTTI
       )
     );
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -18,7 +18,7 @@ import {Logger} from './utils/logger';
 import {LHRunner} from './lh-runner';
 import {Sheets} from './sheets';
 import {adaptMetricsData} from './metrics/metrics-adapter';
-import {validateMetrics, normalizeExpectationMetrics, checkExpectations} from './expectations';
+import {validateMetrics, clarifyMetrics, normalizeExpectationMetrics, checkExpectations} from './expectations';
 import {upload} from './upload';
 import {writeToDisk} from './utils/fs';
 import {getMessage, getMessageWithPrefix} from './utils/messages';
@@ -72,7 +72,8 @@ class PWMetrics {
     if (this.flags.expectations) {
       if (expectations) {
         validateMetrics(expectations);
-        this.normalizedExpectations = normalizeExpectationMetrics(expectations);
+        const actualExpectationMetrics = clarifyMetrics(expectations);
+        this.normalizedExpectations = normalizeExpectationMetrics(actualExpectationMetrics);
       } else throw new Error(getMessageWithPrefix('ERROR', 'NO_EXPECTATIONS_FOUND'));
     }
 

--- a/lib/metrics/metrics-adapter.ts
+++ b/lib/metrics/metrics-adapter.ts
@@ -4,7 +4,7 @@
 import {MetricsResults, Timing} from '../../types/types';
 import {getMessage} from '../utils/messages';
 import {Logger} from '../utils/logger';
-import {METRICS} from './metrics';
+import {METRICS, DEPRECATED_METRICS} from './metrics';
 
 const logger = Logger.getInstance();
 
@@ -41,8 +41,8 @@ export const adaptMetricsData = (res: LH.Result): MetricsResults => {
   const timings: Timing[] = [];
 
   // @todo improve to Object.entries
-  Object.keys(metricsValues).forEach(metricKey => {
-    if (!Object.values(METRICS).includes(metricKey)) return;
+  Object.keys(metricsValues).forEach((metricKey: keyof LH.Artifacts.TimingSummary) => {
+    if (!Object.values(METRICS).includes(metricKey) || DEPRECATED_METRICS.includes(metricKey)) return;
 
     const metricTitle = getMetricTitle(metricKey);
     const resolvedMetric: Timing = {
@@ -54,10 +54,10 @@ export const adaptMetricsData = (res: LH.Result): MetricsResults => {
 
     switch (metricKey) {
       case METRICS.TTFCP:
-      case METRICS.TTFMP:
+      case METRICS.TTLCP:
         resolvedMetric.color = colorP2;
         break;
-      case METRICS.TTFCPUIDLE:
+      case METRICS.TBT:
       case METRICS.TTI:
         resolvedMetric.color = colorP0;
         break;

--- a/lib/metrics/metrics-adapter.ts
+++ b/lib/metrics/metrics-adapter.ts
@@ -8,9 +8,9 @@ import {METRICS} from './metrics';
 
 const logger = Logger.getInstance();
 
-const checkMetrics = (metrics: Record<string, LH.Audit.Result>) => {
+const checkMetrics = (metrics: LH.Audit.Result) => {
   const errorMessage = metrics.errorMessage;
-  const explanation = metrics.details.explanation;
+  const explanation = metrics.explanation;
   if (errorMessage)
     logger.log(`${errorMessage} \n ${explanation}`);
 };
@@ -26,12 +26,11 @@ const getMetricTitle = (metricId) => {
 export const adaptMetricsData = (res: LH.Result): MetricsResults => {
   const auditResults:Record<string, LH.Audit.Result> = res.audits;
 
-  // has to be Record<string, LH.Audit.Result>
-  const metricsAudit:any = auditResults.metrics;
-  if (!metricsAudit || !metricsAudit.details || !metricsAudit.details.items)
+  const metricsAudit = auditResults.metrics;
+  if (!metricsAudit || !metricsAudit.details || !(metricsAudit.details.type === 'debugdata') || !metricsAudit.details.items)
     throw new Error('No metrics data');
 
-  const metricsValues = metricsAudit.details.items[0];
+  const metricsValues: LH.Artifacts.TimingSummary = metricsAudit.details.items[0];
 
   checkMetrics(metricsAudit);
 

--- a/lib/metrics/metrics.ts
+++ b/lib/metrics/metrics.ts
@@ -3,10 +3,19 @@
 
 export const METRICS = {
   TTFCP: 'firstContentfulPaint',
-  TTFMP: 'firstMeaningfulPaint',
-  TTFCPUIDLE: 'firstCPUIdle',
+  TTLCP: 'largestContentfulPaint',
+  TBT: 'totalBlockingTime',
   TTI: 'interactive',
   SI: 'speedIndex',
+  /** @deprecated */
+  TTFMP: 'firstMeaningfulPaint',
+  /** @deprecated */
+  TTFCPUIDLE: 'firstCPUIdle',
   // @todo add in further improvements
   // VISUALLY_COMPLETE: 'observedLastVisualChange',
 };
+
+export const DEPRECATED_METRICS = [
+  METRICS.TTFMP,
+  METRICS.TTFCPUIDLE,
+];

--- a/lib/sheets/index.ts
+++ b/lib/sheets/index.ts
@@ -56,9 +56,9 @@ export class Sheets {
         data.requestedUrl,
         `${dateObj.toLocaleDateString()} ${dateObj.toLocaleTimeString()}`,
         getTiming(METRICS.TTFCP),
-        getTiming(METRICS.TTFMP),
+        getTiming(METRICS.TTLCP),
         getTiming(METRICS.SI),
-        getTiming(METRICS.TTFCPUIDLE),
+        getTiming(METRICS.TBT),
         getTiming(METRICS.TTI),
       ]);
     });

--- a/lib/utils/messages.ts
+++ b/lib/utils/messages.ts
@@ -52,6 +52,8 @@ export const getMessage = function (messageType: string, ...args: any[]) {
       return `No matching message prefix: ${args[0]}`;
     case 'METRIC_IS_UNAVAILABLE':
       return `Sorry, ${args[0]} metric is unavailable`;
+    case 'METRIC_IS_DEPRECATED':
+      return `Sorry, ${args[0]} metric is deprecated and cannot be used`;
     case METRICS.TTFCP:
       return 'First Contentful Paint';
     case METRICS.TTFMP:

--- a/lib/utils/messages.ts
+++ b/lib/utils/messages.ts
@@ -62,6 +62,10 @@ export const getMessage = function (messageType: string, ...args: any[]) {
       return 'First CPU Idle';
     case METRICS.TTI:
       return 'Time to Interactive';
+    case METRICS.TTLCP:
+      return 'Largest Contentful Paint';
+    case METRICS.TBT:
+      return 'Total Blocking Time';
     case 'SUCCESS_RUN':
       return `Run ${args[0] + 1} of ${args[1]} finished successfully`;
     case 'FAILED_RUN':

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "chrome-launcher": "^0.10.2",
     "google-auth-library": "^0.10.0",
     "googleapis": "^47.0.0",
-    "lighthouse": "^5.2.0",
+    "lighthouse": "^6.0.0",
     "micro-promisify": "^0.1.1",
     "open": "^6.4.0",
     "readline-sync": "^1.4.6",
@@ -30,14 +30,14 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "devtools-protocol": "^0.0.589586",
+    "devtools-protocol": "^0.0.739646",
     "eslint": "^3.12.0",
     "eslint-config-google": "^0.7.1",
     "gulp": "^3.9.1",
     "mocha": "^3.2.0",
     "sinon": "^1.17.7",
     "sinon-chai": "^2.8.0",
-    "typescript": "3.0.1"
+    "typescript": "3.8.3"
   },
   "repository": {
     "type": "git",

--- a/readme.md
+++ b/readme.md
@@ -41,8 +41,8 @@ pwmetrics http://example.com/ --json
 #       "value": 289.642
 #     },
 #     {
-#       "name": "First Meaningful Paint",
-#       "value": 289.6
+#       "name": "Largest Contentful Paint",
+#       "value": 292
 #     },
 #     ...
 
@@ -136,14 +136,14 @@ module.exports = {
       warn: '>=1500',
       error: '>=2000'
     },
-    [METRICS.TTFMP]: {
+    [METRICS.TTLCP]: {
       warn: '>=2000',
       error: '>=3000'
     },
     [METRICS.TTI]: {
       ...
     },
-    [METRICS.TTFCPUIDLE]: {
+    [METRICS.TBT]: {
       ...
     },
     [METRICS.SI]: {
@@ -316,8 +316,8 @@ All metrics now are stored in separate constant object located in `pwmetrics/lib
 {
   METRICS: {
     TTFCP: 'firstContentfulPaint',
-    TTFMP: 'firstMeaningfulPaint',
-    TTFCPUIDLE: 'firstCPUIdle',
+    TTLCP: 'largestContentfulPaint',
+    TBT: 'totalBlockingTime',
     TTI: 'interactive',
     SI: 'speedIndex'
   }

--- a/test/fixtures/events.json
+++ b/test/fixtures/events.json
@@ -14,14 +14,18 @@
       "scoreDisplayMode": "informative",
       "rawValue": 4179.649,
       "details": {
+        "type": "debugdata",
         "items": [
           {
             "firstContentfulPaint": 4180,
             "firstMeaningfulPaint": 4180,
+            "largestContentfulPaint": 4329,
             "firstCPUIdle": 4180,
             "interactive": 4180,
             "speedIndex": 4329,
             "estimatedInputLatency": 13,
+            "totalBlockingTime": 408,
+            "cumulativeLayoutShift": 0.0053,
             "observedNavigationStart": 0,
             "observedNavigationStartTs": 49414590783,
             "observedFirstPaint": 1005,

--- a/test/fixtures/metrics-results.json
+++ b/test/fixtures/metrics-results.json
@@ -7,16 +7,10 @@
       "color": "green"
     },
     {
-      "title": "First Meaningful Paint",
-      "id": "firstMeaningfulPaint",
-      "timing": 4180,
+      "title": "Largest Contentful Paint",
+      "id": "largestContentfulPaint",
+      "timing": 4329,
       "color": "green"
-    },
-    {
-      "title": "First CPU Idle",
-      "id": "firstCPUIdle",
-      "timing": 4180,
-      "color": "yellow"
     },
     {
       "title": "Time to Interactive",
@@ -29,6 +23,12 @@
       "id": "speedIndex",
       "timing": 4329,
       "color": "blue"
+    },
+    {
+      "title": "Total Blocking Time",
+      "id": "totalBlockingTime",
+      "timing": 408,
+      "color": "yellow"
     }
   ],
   "generatedTime": "2018-08-27T20:53:51.206Z",

--- a/test/metrics.js
+++ b/test/metrics.js
@@ -27,7 +27,7 @@ describe('Metrics', () => {
     it('should log error if audit has debugString', () => {
       const {audits} = events;
       audits.metrics.errorMessage = 'Cannot read property \'ts\' of undefined';
-      audits.metrics.details.explanation = 'Explanation of error';
+      audits.metrics.explanation = 'Explanation of error';
       adaptMetricsData(events);
       expect(logSpy).to.be.calledWith('Cannot read property \'ts\' of undefined \n Explanation of error');
     });

--- a/types/types.ts
+++ b/types/types.ts
@@ -72,9 +72,9 @@ export interface GSheetsValuesToAppend {
   1: string; // url
   2: string; // time
   3: number; // TTFCP timing
-  4: number; // TTFMP timing
+  4: number; // TTLCP timing
   5: number; // SI timing
-  6: number; // TTFCPUIDLE timing
+  6: number; // TBT timing
   7: number; // TTI timing
 }
 


### PR DESCRIPTION
So, this is actually just the basic update to a new Lighthouse version in order to get access to the [new metrics](https://web.dev/lighthouse-whats-new-6.0/#new-metrics).

I threw out Cumulative Layout Shift metric because it has only 5% impact to final score. And also First Meaningful Paint and First CPU Idle metrics have been deprecated in LH v6 update.

There are more new stuff in new LH version which should be (re)implemented, such as timing budgets and unused js. But I think it could be done in later PRs (not mine, just speaking in common)

Any thoughts/suggestions?