### PR TITLE
Merge CLI flags with flags found in config file.

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -83,8 +83,10 @@ const cliFlags = yargs
   .epilogue('For more Lighthouse CLI options see https://github.com/GoogleChrome/lighthouse/#lighthouse-cli-options')
   .argv;
 
-// Merge options from all sources. Order indicates precedence (last one wins)
-const options = Object.assign({}, {flags: cliFlags}, config);
+const options = config || {};
+
+// Merge flags from CLI and config file (if present). Config flags take precedence.
+options.flags = Object.assign({}, cliFlags, options.flags);
 
 // Get url first from cmd line then from config file.
 options.url = cliFlags._[0] || options.url;

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "mocha": "^3.2.0",
     "sinon": "^1.17.7",
     "sinon-chai": "^2.8.0",
-    "typescript": "3.0.1"
+    "typescript": "3.5.1"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4002,10 +4002,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
-  integrity sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==
+typescript@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
+  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
 
 ultron@~1.1.0:
   version "1.1.1"


### PR DESCRIPTION
I believe the desired behavior is to merge these flags so that users can specify both CLI flags and a config file simultaneously. As it stands, when a config file is specified, it's flags will replace (and erase) any flags passed through CLI.

Note, I had to upgrade Typescript by a few minor versions because I was getting a TS build error `Cannot find name 'Omit'.`, and I saw that TS 3.0 didn't support it. So I bumped TS to 3.5 and everything seemed to be working. We'll see what travis says.

Fixes #150.